### PR TITLE
Exports

### DIFF
--- a/exports2/README.md
+++ b/exports2/README.md
@@ -1,0 +1,1 @@
+ref: [Node.jsのexportsとmodule.exportsの違いについてのメモ - Qiita](https://qiita.com/toshihirock/items/e98363a4c99950be5abc)

--- a/exports2/main.js
+++ b/exports2/main.js
@@ -1,0 +1,5 @@
+const util = require('./util')
+
+util.sayAdd(1, 2)
+util.saySubtract(2, 1)
+util.say()

--- a/exports2/main2.js
+++ b/exports2/main2.js
@@ -1,0 +1,8 @@
+const Movie = require('./movie')
+
+const movieA = new Movie('Star Wars')
+movieA.sayTitle()
+
+const movieB = new Movie('Mad Max')
+movieB.sayTitle()
+movieB.say()

--- a/exports2/movie.js
+++ b/exports2/movie.js
@@ -1,13 +1,11 @@
-const Movie = function(title) {
+module.exports = function(title) {
   this.title = title
+
+  this.sayTitle = function() {
+    say(this.title)
+  }
 }
 
-Movie.prototype.sayTitle = function() {
-  say(this.title)
-}
-
-say = function(word) {
+function say(word) {
   console.log(word)
 }
-
-module.exports = Movie

--- a/exports2/movie.js
+++ b/exports2/movie.js
@@ -1,0 +1,13 @@
+const Movie = function(title) {
+  this.title = title
+}
+
+Movie.prototype.sayTitle = function() {
+  say(this.title)
+}
+
+say = function(word) {
+  console.log(word)
+}
+
+module.exports = Movie

--- a/exports2/util.js
+++ b/exports2/util.js
@@ -1,0 +1,11 @@
+exports.sayAdd = function(a, b) {
+  say(a + b)
+}
+
+exports.saySubtract = function(a, b) {
+  say(a - b)
+}
+
+function say(word) {
+  console.log(word)
+}

--- a/exports3/README.md
+++ b/exports3/README.md
@@ -1,0 +1,1 @@
+ref: [Node.js : exports と module.exports の違い（解説編） - ぼちぼち日記](http://d.hatena.ne.jp/jovi0608/20111226/1324879536)

--- a/exports3/main.js
+++ b/exports3/main.js
@@ -1,0 +1,3 @@
+const myMod = require('./mymodule')
+
+myMod.name()

--- a/exports3/main.js
+++ b/exports3/main.js
@@ -1,3 +1,1 @@
-const myMod = require('./mymodule')
-
-myMod.name()
+console.log(require('./mymodule'))

--- a/exports3/mymodule.js
+++ b/exports3/mymodule.js
@@ -1,3 +1,5 @@
+module.exports = 'Hi'
+
 exports.name = function() {
   console.log('My Name is yinm.')
 }

--- a/exports3/mymodule.js
+++ b/exports3/mymodule.js
@@ -1,2 +1,2 @@
 exports.hoge = 'hoge'
-module.exports.foo = 'foo'
+module.exports = {foo: 'foo'}

--- a/exports3/mymodule.js
+++ b/exports3/mymodule.js
@@ -1,5 +1,2 @@
-module.exports = 'Hi'
-
-exports.name = function() {
-  console.log('My Name is yinm.')
-}
+exports.hoge = 'hoge'
+module.exports.foo = 'foo'

--- a/exports3/mymodule.js
+++ b/exports3/mymodule.js
@@ -1,0 +1,3 @@
+exports.name = function() {
+  console.log('My Name is yinm.')
+}

--- a/exports4/README.md
+++ b/exports4/README.md
@@ -1,0 +1,1 @@
+ref: [Node.jsのexportsについて - 30歳からのプログラミング](https://numb86-tech.hatenablog.com/entry/2016/07/20/202744)

--- a/exports4/app.js
+++ b/exports4/app.js
@@ -1,0 +1,4 @@
+const myModules = require('./modules')
+
+console.log(myModules.data.int)
+console.log(myModules.cal.add(myModules.data.int, 2))

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,4 +1,5 @@
 const parts = require('./parts')
 
-console.log(parts.value)
-console.log(parts.fuga)
+console.log(parts)
+
+require('./parts')

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,6 +1,4 @@
 const parts = require('./parts')
 
 console.log(parts.int)
-
-require('./parts')
-console.log(parts.int)
+parts.myFunc(2)

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,5 +1,6 @@
 const parts = require('./parts')
 
-console.log(parts)
+console.log(parts.int)
 
 require('./parts')
+console.log(parts.int)

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,4 +1,5 @@
 const parts = require('./parts')
 
-console.log(parts.int)
-parts.myFunc(2)
+parts.showResult(2, 3)
+console.log('showResult' in parts)
+console.log('add' in parts)

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,0 +1,4 @@
+const parts = require('./parts')
+
+console.log(parts.value)
+console.log(parts.foo)

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,4 +1,4 @@
 const parts = require('./parts')
 
 console.log(parts.value)
-console.log(parts.foo)
+console.log(parts.fuga)

--- a/exports4/index.js
+++ b/exports4/index.js
@@ -1,5 +1,7 @@
 const parts = require('./parts')
 
-parts.showResult(2, 3)
-console.log('showResult' in parts)
-console.log('add' in parts)
+console.log(parts.int)
+console.log(parts.get())
+
+parts.increment()
+console.log(parts.get())

--- a/exports4/modules/cal.js
+++ b/exports4/modules/cal.js
@@ -1,0 +1,4 @@
+function add(a, b) {
+  return a + b
+}
+module.exports.add = add

--- a/exports4/modules/data.js
+++ b/exports4/modules/data.js
@@ -1,0 +1,2 @@
+let int = 1
+module.exports.int = int

--- a/exports4/modules/index.js
+++ b/exports4/modules/index.js
@@ -1,0 +1,2 @@
+module.exports.cal = require('./cal')
+module.exports.data = require('./data')

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,12 +1,7 @@
-let int = 0
+console.log(module.exports === exports)
 
-function increment() {
-  int++
-}
+exports.foo = 'foo'
+console.log(module.exports === exports)
 
-function get() {
-  return int
-}
-
-module.exports.increment = increment
-module.exports.get = get
+exports = 'bar'
+console.log(module.exports === exports)

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,7 +1,9 @@
-let int = 10
-
-function myFunc(arg) {
-  console.log(arg * int)
+function add(a, b) {
+  return a + b
 }
 
-module.exports.myFunc = myFunc
+function showResult(a, b) {
+  console.log( add(a, b) )
+}
+
+module.exports.showResult = showResult

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,7 +1,11 @@
 const value = '値'
 const foo = 'foo'
+console.log(module.exports === exports)
+
 module.exports = {
-  fuga: 'fuga',
+  fuga: 'fuga'
 }
+console.log(module.exports === exports)
 
 exports.value = value
+console.log(module.exports === exports)

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,3 +1,4 @@
-const value = '値'
-const foo = 'foo'
-exports.value = value
+module.exports = {
+  value: '値',
+  foo: 'foo',
+}

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,1 +1,4 @@
-console.log('read a file.')
+let int = 0
+int++
+
+module.exports.int = int

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,4 +1,2 @@
-module.exports = {
-  value: '値',
-  foo: 'foo',
-}
+module.exports.value = '値'
+module.exports.foo = 'foo'

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,9 +1,12 @@
-function add(a, b) {
-  return a + b
+let int = 0
+
+function increment() {
+  int++
 }
 
-function showResult(a, b) {
-  console.log( add(a, b) )
+function get() {
+  return int
 }
 
-module.exports.showResult = showResult
+module.exports.increment = increment
+module.exports.get = get

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,0 +1,3 @@
+const value = '値'
+const foo = 'foo'
+exports.value = value

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,2 +1,7 @@
-module.exports.value = '値'
-module.exports.foo = 'foo'
+const value = '値'
+const foo = 'foo'
+module.exports = {
+  fuga: 'fuga',
+}
+
+exports.value = value

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,4 +1,7 @@
-let int = 0
-int++
+let int = 10
 
-module.exports.int = int
+function myFunc(arg) {
+  console.log(arg * int)
+}
+
+module.exports.myFunc = myFunc

--- a/exports4/parts.js
+++ b/exports4/parts.js
@@ -1,11 +1,1 @@
-const value = '値'
-const foo = 'foo'
-console.log(module.exports === exports)
-
-module.exports = {
-  fuga: 'fuga'
-}
-console.log(module.exports === exports)
-
-exports.value = value
-console.log(module.exports === exports)
+console.log('read a file.')


### PR DESCRIPTION
### `exports`と`module.exports`の関係
- 初期状態では、`exports`は`module.exports`を参照しており、両者は同じものを指している (`exports = module.exports = {}`)
- `exports === module.exports`の関係が途切れるケース
  - module.exportsに代入した場合
  - exportsに直接代入した場合 (e.g. `exports = 'foo'`)
    - ただし、exportsのプロパティに代入した場合は関係は途切れない (e.g. `exports.foo = 'foo'`)
- `require()`によって最終的に評価されるのは、`module.exports`
  - そのため、常に`module.exports`を使うようにすれば混乱は少ない

### `require()`の挙動
  - ファイルの中身を実行して、`module.exports`を返す
  - 同一ファイルに対しては一度しか実行しない
  - 引数にディレクトリを渡すと、そのディレクトリの`index.js`を実行する。なので、index.jsをエントリポイントにして、複数ファイルの読み込みを簡単にできる

### 参考
- [Node.jsのexportsについて - 30歳からのプログラミング](https://numb86-tech.hatenablog.com/entry/2016/07/20/202744)
- [exports と module.exports の違い - Qiita](https://qiita.com/kuboon/items/cb1b532ac8a8959973b2)